### PR TITLE
Add CreateChannel, Channel containers

### DIFF
--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -3,18 +3,18 @@ import { Route } from 'react-router';
 
 import Login from '../Login/Login';
 import HomeContainer from '../../containers/HomeContainer';
-import CreateChannel from '../CreateChannel/CreateChannel';
+import CreateChannelContainer from '../../containers/CreateChannelContainer';
 import FindChannel from '../FindChannel/FindChannel';
-import Channel from '../Channel/Channel';
+import ChannelContainer from '../../containers/ChannelContainer';
 
 const Routes = () => {
   return (
     <div>
       <Route exact path="/" component={ Login } />
       <Route exact path="/home" component={ HomeContainer } />
-      <Route exact path="/create-channel" component={ CreateChannel } />
+      <Route exact path="/create-channel" component={ CreateChannelContainer } />
       <Route exact path="/find-channel" component={ FindChannel } />
-      <Route exact path="/franklin-channel" component={ Channel } />
+      <Route exact path="/channel" component={ ChannelContainer } />
     </div>
   )
 }

--- a/src/containers/ChannelContainer.js
+++ b/src/containers/ChannelContainer.js
@@ -1,0 +1,15 @@
+import * as actionCreators from '../actions/actions';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import Channel from '../components/Channel/Channel';
+
+const mapStateToProps = (state) => {
+  return { ...state, user: state.user };
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators(actionCreators, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Channel);

--- a/src/containers/CreateChannelContainer.js
+++ b/src/containers/CreateChannelContainer.js
@@ -1,0 +1,15 @@
+import * as actionCreators from '../actions/actions';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import CreateChannel from '../components/CreateChannel/CreateChannel';
+
+const mapStateToProps = (state) => {
+  return { ...state, user: state.user };
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators(actionCreators, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateChannel);


### PR DESCRIPTION
User is getting passed to CreateChannel, and should make it to Channel except for the fact that our routes aren't set up fully, so when you navigate to /channel manually, it refreshes and dumps the user object out of state. I think.