### PR TITLE
Jk playlist

### DIFF
--- a/src/components/Channel/Channel.js
+++ b/src/components/Channel/Channel.js
@@ -30,12 +30,11 @@ class Channel extends Component {
   }
 
   render(){
-    const { uri } = this.props.playlist;
-    console.log(uri);
+    // const { uri } = this.props.playlist;
+    const uri = 'spotify:user:126858355:playlist:2maWm9kDvv9T9vJMmpTvI7';
+
     return (
       <div>
-
-        {/* GRAB playlist endpoint and throw in this url */}
         <div className="playlist-wrapper">
           <iframe src={`https://open.spotify.com/embed?uri=${uri}&theme=white`} 
                   height="80" 
@@ -49,9 +48,6 @@ class Channel extends Component {
           <button onClick={() => this.searchTracks()}>submit</button>
           { this.state.searchTracks.length && this.displayTracks() }
         </div>
-        
-
-        <h1>PLAYER WIDGET</h1>
 
         <ul>
           <li>Tim</li>

--- a/src/components/Channel/Channel.js
+++ b/src/components/Channel/Channel.js
@@ -30,15 +30,17 @@ class Channel extends Component {
   }
 
   render(){
+    const { uri } = this.props.playlist;
+    console.log(uri);
     return (
       <div>
 
         {/* GRAB playlist endpoint and throw in this url */}
         <div className="playlist-wrapper">
-          <iframe src="https://open.spotify.com/embed?uri=spotify%3Auser%3Aspotify%3Aplaylist%3A2PXdUld4Ueio2pHcB6sM8j&theme=white" 
+          <iframe src={`https://open.spotify.com/embed?uri=${uri}&theme=white`} 
                   height="80" 
-                  frameborder="0" 
-                  allowtransparency="true"></iframe>
+                  frameBorder="0" 
+                  allowTransparency="true"></iframe>
         </div>
         
         <div className="search-wrapper">

--- a/src/components/Channel/ChannelContainer.js
+++ b/src/components/Channel/ChannelContainer.js
@@ -6,7 +6,10 @@ import { connect } from 'react-redux';
 import Channel from './Channel';
 
 const mapStateToProps = (state) => {
-  return { ...state, user: state.user };
+  return { ...state, 
+           user: state.user,
+           playlist: state.playlist
+         };
 }
 
 const mapDispatchToProps = (dispatch) => {


### PR DESCRIPTION
Ok, good news and bad news here.

Good news is that we are getting playlists back and "into" the iframe.

Bad news is that apparently the iframe is not a player. Which means that it is really just a link to open a playlist in Spotify's web or desktop player. Sooooo.... that really sucks, wish I'd caught it sooner. I don't think there's much we can do about it at this point.

Also bad news, the player is loading but then console blows up with an error saying it can't GET the playlist. I think has something with react/redux repeatedly triggering the GET request for that URI.