### PR TITLE
Add basic socket connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "express": "4.4.3",
     "express-cors": "^0.0.3",
     "express-session": "1.4.0",
+    "http": "0.0.0",
     "isomorphic-fetch": "^2.2.1",
     "method-override": "2.0.2",
     "passport": "~0.2.0",
@@ -22,7 +23,9 @@
     "react-router-dom": "^4.0.0",
     "react-router-redux": "^4.0.8",
     "redux": "^3.6.0",
+    "redux-socket.io": "^1.4.0",
     "redux-thunk": "^2.2.0",
+    "socket.io-client": "^2.0.2",
     "spotify-web-api-node": "^2.4.0",
     "swig": "~1.3.2"
   },

--- a/server.js
+++ b/server.js
@@ -21,10 +21,29 @@ const testPlaylist = config.test_playlist
 
 const redirect_uri = 'http://localhost:8888/callback';
 const passport = require('passport')
+const socket_io = require('socket.io');
+const io = socket_io();
+const http = require('http');
+const PORT = process.env.PORT || 8888
+
 
 const express = require('express');
 const app = express();
 
+const server = http.createServer(app).listen(PORT, () => {
+  console.log(`server listending on port ${PORT}`)
+});
+
+io.attach(server);
+io.on('connection', function(socket) {
+  console.log('Socket connected: ' + socket.id);
+  socket.on('action', (action) => {
+    if(action.type === 'app/hello') {
+      console.log('Got hello data!', action.data);
+      socket.emit('action', {type: 'message', data: 'boom'});
+    }
+  });
+});
 
 /********************** CONFIGURATION ***********************/
 
@@ -55,11 +74,10 @@ app.use(function(req, res, next) {
 
 /********************** PORT ***********************/
 
-const PORT = process.env.PORT || 8888
 
-app.listen(PORT, () => {
-  console.log(`Listening on ${PORT}`);
-});
+// app.listen(PORT, () => {
+//   console.log(`Listening on ${PORT}`);
+// });
 
 
 /********************** PASSPORT ***********************/

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -14,7 +14,6 @@ export const profileFetch = (dispatch) => {
   }
 }
 
-
 const createPlayList = (playlist) => {
   console.log("hit");
   return {
@@ -40,7 +39,6 @@ export const createPlaylistPost = (dispatch) => {
       .catch(error => console.log(error))
   }
 }
-
 
 const sendSongs = (songs) => {
   return {

--- a/src/components/Channel/Channel.js
+++ b/src/components/Channel/Channel.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import './Channel.css'
-
+import './Channel.css';
 
 class Channel extends Component {
   constructor() {
@@ -11,6 +10,15 @@ class Channel extends Component {
       searchTracks: [],
       display: 'hidden'
     }
+  }
+  
+  componentDidMount() {
+    var socket = require('socket.io-client')();
+    socket.on('connect', function(){
+      console.log('is this fucking hooked up yet?');
+    });
+    // socket.on('event', function(data){});
+    // socket.on('disconnect', function(){});
   }
 
   displayTracks(){

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import './Login.css'
+import './Login.css';
 
 const Login = () => {
+  
   return (
     <div>
       <h1>welcome to <span className="logo">earsnakk</span></h1>

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,24 @@ import { render } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 // import thunk from 'redux-thunk';
+import store from './store';
 
 import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';
-import configureStore from './store';
+// import configureStore from './store';
 
 import './index.css';
 
-const store = configureStore();
+// const store = configureStore();
+
+store.subscribe(() => {
+  console.log('new client state', store.getState());
+});
+
+store.dispatch({
+  type: 'server/hello',
+  data: 'Hello'
+});
 
 const Root = () => {
   return (

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import user from './user';
 import playlist from './playlist';
 import searchSongs from './searchSongs';
+import testReducer from './testReducer';
 
 const rootReducer = combineReducers({
   playlist,
   user,
-  searchSongs
+  searchSongs,
+  testReducer
 });
 
 export default rootReducer;

--- a/src/reducers/testReducer.js
+++ b/src/reducers/testReducer.js
@@ -1,0 +1,12 @@
+
+function testReducer(state = {}, action) {
+  console.log('test reducer');
+  switch(action.type) {
+    case 'message':
+      return Object.assign({}, {message:action.data});
+    default:
+      return state;
+  }
+}
+
+export default testReducer;

--- a/src/store.js
+++ b/src/store.js
@@ -1,16 +1,26 @@
 import { createStore, applyMiddleware } from 'redux';
 import rootReducer from './reducers/index';
 import thunk from 'redux-thunk';
+import createSocketIoMiddleware from 'redux-socket.io';
+import io from 'socket.io-client';
 
 const devTools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 
-const configureStore = () => {
-  const store = createStore(
-    rootReducer,
-    devTools,
-    applyMiddleware(thunk)
-  );
-  return store;
-}
+let socket = io('http://localhost:3000');
+let socketIoMiddleware = createSocketIoMiddleware(socket, "server/");
 
-export default configureStore;
+
+let store = applyMiddleware(socketIoMiddleware, thunk)(createStore)(rootReducer);
+
+export default store;
+
+// const configureStore = () => {
+//   const store = createStore(
+//     rootReducer,
+//     devTools,
+//     applyMiddleware(thunk)
+//   );
+//   return store;
+// }
+
+// export default configureStore;


### PR DESCRIPTION
Ok, basic socket connection in place. Basically, we are not telling Redux to automatically pay attention to sockets, because it doesn't need to. So right now there is a socket that opens between channel and the server. We may need to have that socket open earlier so that both channel host and guests end up on the same connection, haven't looked into that yet but could be an issue.

But anyway, we just need for a host to listen to sockets, and then when their channel hears a socket emit a song URI, have that trigger an action that posts the song to the the playlist.